### PR TITLE
Pressure Pad changes

### DIFF
--- a/Assets/EscenaJuego.unitypackage.meta
+++ b/Assets/EscenaJuego.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 9b3292d0890af054e8a6b5f0f64797e2
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Interior.unitypackage.meta
+++ b/Assets/Interior.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 8a3700e52a39d0945af351b608173b09
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scenes/TestingScene.unity
+++ b/Assets/Scenes/TestingScene.unity
@@ -1592,67 +1592,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ce81d0389e0205c4cb629a689e773688, type: 3}
---- !u!1001 &501622747
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4025159523980785052, guid: 57f9c7f4685406e4d9dc3f803fdc4c8b, type: 3}
-      propertyPath: m_Name
-      value: PressurePlate
-      objectReference: {fileID: 0}
-    - target: {fileID: 7421176533045013491, guid: 57f9c7f4685406e4d9dc3f803fdc4c8b, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 75.16
-      objectReference: {fileID: 0}
-    - target: {fileID: 7421176533045013491, guid: 57f9c7f4685406e4d9dc3f803fdc4c8b, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 28.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 7421176533045013491, guid: 57f9c7f4685406e4d9dc3f803fdc4c8b, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7421176533045013491, guid: 57f9c7f4685406e4d9dc3f803fdc4c8b, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7421176533045013491, guid: 57f9c7f4685406e4d9dc3f803fdc4c8b, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7421176533045013491, guid: 57f9c7f4685406e4d9dc3f803fdc4c8b, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7421176533045013491, guid: 57f9c7f4685406e4d9dc3f803fdc4c8b, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7421176533045013491, guid: 57f9c7f4685406e4d9dc3f803fdc4c8b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7421176533045013491, guid: 57f9c7f4685406e4d9dc3f803fdc4c8b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7421176533045013491, guid: 57f9c7f4685406e4d9dc3f803fdc4c8b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7673268181757289225, guid: 57f9c7f4685406e4d9dc3f803fdc4c8b, type: 3}
-      propertyPath: _objectLayer.m_Bits
-      value: 6408
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 57f9c7f4685406e4d9dc3f803fdc4c8b, type: 3}
 --- !u!1 &599453401
 GameObject:
   m_ObjectHideFlags: 0
@@ -44879,6 +44818,197 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e1e17820a3e547a4594e28877a6866aa, type: 3}
+--- !u!1 &1371100186
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1371100192}
+  - component: {fileID: 1371100191}
+  - component: {fileID: 1371100190}
+  - component: {fileID: 1371100189}
+  - component: {fileID: 1371100188}
+  - component: {fileID: 1371100187}
+  m_Layer: 3
+  m_Name: MovableObject (2)
+  m_TagString: Pushable
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1371100187
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371100186}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 43b116b25d39bd04c969217527fcbb25, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  weight: 2.5
+--- !u!50 &1371100188
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371100186}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!114 &1371100189
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371100186}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 092f7bc1f73510d4fb7b4e632a22b58c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _moveSmoothTime: 0.2
+  _stopThreshold: 0.05
+  _moovingSFX: {fileID: 8300000, guid: 43670071cc2fe50e6bde2890c6188354, type: 3}
+  _obstacleMask:
+    serializedVersion: 2
+    m_Bits: 22784
+--- !u!61 &1371100190
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371100186}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.0019227266, y: -0.006275058}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.8726377, y: 1.8550425}
+  m_EdgeRadius: 0
+--- !u!212 &1371100191
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371100186}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1151905791
+  m_SortingLayer: 5
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -801018001, guid: aba8a17141c14494cabbb5c95b00401f, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1371100192
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1371100186}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 83.389, y: 33.39, z: 0.000000059604645}
+  m_LocalScale: {x: 0.63761, y: 0.63761, z: 0.63761}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1421343290
 GameObject:
   m_ObjectHideFlags: 0
@@ -45850,79 +45980,6 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
---- !u!1001 &1676813240
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1885525747835525236, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 81.96001
-      objectReference: {fileID: 0}
-    - target: {fileID: 1885525747835525236, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 28.019966
-      objectReference: {fileID: 0}
-    - target: {fileID: 1885525747835525236, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.000000059604645
-      objectReference: {fileID: 0}
-    - target: {fileID: 1885525747835525236, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1885525747835525236, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1885525747835525236, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1885525747835525236, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1885525747835525236, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1885525747835525236, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1885525747835525236, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4526406250031599650, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
-      propertyPath: m_Name
-      value: MovableObject (1)
-      objectReference: {fileID: 0}
-    - target: {fileID: 8030402128500837653, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
-      propertyPath: m_Size.x
-      value: 1.8726377
-      objectReference: {fileID: 0}
-    - target: {fileID: 8030402128500837653, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
-      propertyPath: m_Size.y
-      value: 1.8550425
-      objectReference: {fileID: 0}
-    - target: {fileID: 8030402128500837653, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
-      propertyPath: m_Offset.x
-      value: 0.0019227266
-      objectReference: {fileID: 0}
-    - target: {fileID: 8030402128500837653, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
-      propertyPath: m_Offset.y
-      value: -0.006275058
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4d0dddb38cbb4f74296ceb01c84f9b36, type: 3}
 --- !u!1 &1726128777 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7191502616451256375, guid: 5045893a5b4bbb848ac5e0290e640c7c, type: 3}
@@ -46491,6 +46548,153 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _director: {fileID: 2095174532}
   _cinematicController: {fileID: 2095174536}
+--- !u!114 &748283135420679623
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4526406250561270682}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 092f7bc1f73510d4fb7b4e632a22b58c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _moveSmoothTime: 0.2
+  _stopThreshold: 0.05
+  _moovingSFX: {fileID: 8300000, guid: 43670071cc2fe50e6bde2890c6188354, type: 3}
+  _obstacleMask:
+    serializedVersion: 2
+    m_Bits: 22784
+--- !u!95 &1670828316637538664
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4025159524309635655}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 7bea1ae82320d294ab569e34dbcbd3a6, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!4 &1885525746204867532
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4526406250561270682}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 76.35, y: 33.34, z: 0.000000059604645}
+  m_LocalScale: {x: 0.63761, y: 0.63761, z: 0.63761}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &3265080076024025728
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4025159524309635655}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -788570445
+  m_SortingLayer: 1
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 172059119, guid: aba8a17141c14494cabbb5c95b00401f, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.109375, y: 1.109375}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &4025159524309635655
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7421176532690455592}
+  - component: {fileID: 8897391461635484240}
+  - component: {fileID: 3265080076024025728}
+  - component: {fileID: 7673268181793064146}
+  - component: {fileID: 1670828316637538664}
+  m_Layer: 0
+  m_Name: PressurePlate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &4526406250561270682
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1885525746204867532}
+  - component: {fileID: 7603374926709875861}
+  - component: {fileID: 8030402126929161901}
+  - component: {fileID: 748283135420679623}
+  - component: {fileID: 7385902471704992357}
+  - component: {fileID: 8030402126929161902}
+  m_Layer: 3
+  m_Name: MovableObject (1)
+  m_TagString: Pushable
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1001 &6234525673064903028
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -46620,6 +46824,219 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6e20349c3c1bb62459d5ab2cce49c113, type: 3}
+--- !u!50 &7385902471704992357
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4526406250561270682}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!4 &7421176532690455592
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4025159524309635655}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 79.98, y: 33.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &7603374926709875861
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4526406250561270682}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1151905791
+  m_SortingLayer: 5
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -801018001, guid: aba8a17141c14494cabbb5c95b00401f, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &7673268181793064146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4025159524309635655}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0764680abdfc3154aa90889b8a51e472, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  triggerWeight: 5
+  totalWeight: 0
+  _needHold: 0
+  _audioClip: {fileID: 8300000, guid: bd9600329aad14d4db6064c118dd72b3, type: 3}
+--- !u!61 &8030402126929161901
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4526406250561270682}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.0019227266, y: -0.006275058}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2, y: 2}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.8726377, y: 1.8550425}
+  m_EdgeRadius: 0
+--- !u!114 &8030402126929161902
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4526406250561270682}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 43b116b25d39bd04c969217527fcbb25, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  weight: 2.5
+--- !u!61 &8897391461635484240
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4025159524309635655}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0.27676392}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 3.25, y: 1.8125}
+    newSize: {x: 1.109375, y: 1.109375}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 2, y: 1.4464722}
+  m_EdgeRadius: 0
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -46631,8 +47048,9 @@ SceneRoots:
   - {fileID: 132527962}
   - {fileID: 499660063}
   - {fileID: 1353071419}
-  - {fileID: 501622747}
   - {fileID: 974910000}
-  - {fileID: 1676813240}
   - {fileID: 886478172}
   - {fileID: 387913841}
+  - {fileID: 7421176532690455592}
+  - {fileID: 1885525746204867532}
+  - {fileID: 1371100192}

--- a/Assets/Scenes/TestingScene.unity
+++ b/Assets/Scenes/TestingScene.unity
@@ -180,11 +180,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6170821206192857187, guid: 35def2087b57eb443832914bf1ec3cd3, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -248.59
+      value: -234.76
       objectReference: {fileID: 0}
     - target: {fileID: 6170821206192857187, guid: 35def2087b57eb443832914bf1ec3cd3, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 40.71
+      value: 43.75
       objectReference: {fileID: 0}
     - target: {fileID: 6170821206192857187, guid: 35def2087b57eb443832914bf1ec3cd3, type: 3}
       propertyPath: m_LocalPosition.z
@@ -936,7 +936,7 @@ Transform:
   m_GameObject: {fileID: 318954088}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -248.59, y: 40.71, z: -10}
+  m_LocalPosition: {x: -234.76, y: 43.75, z: -10}
   m_LocalScale: {x: 0.80645, y: 0.80645, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -42331,115 +42331,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _scaleSpeed: 2
   _scaleAmount: 0.1
---- !u!1001 &974910000
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 665811397658276542, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_Name
-      value: SlideFloor
-      objectReference: {fileID: 0}
-    - target: {fileID: 3525975874881380881, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.052
-      objectReference: {fileID: 0}
-    - target: {fileID: 3525975874881380881, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5362467324627364834, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.95
-      objectReference: {fileID: 0}
-    - target: {fileID: 6698123142023258371, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6698123142023258371, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.045
-      objectReference: {fileID: 0}
-    - target: {fileID: 7364058690186325030, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_Color.a
-      value: 0.78039217
-      objectReference: {fileID: 0}
-    - target: {fileID: 7364058690186325030, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_Color.b
-      value: 0.11764705
-      objectReference: {fileID: 0}
-    - target: {fileID: 7364058690186325030, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_Color.g
-      value: 0.34196767
-      objectReference: {fileID: 0}
-    - target: {fileID: 7364058690186325030, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_Color.r
-      value: 0.8666667
-      objectReference: {fileID: 0}
-    - target: {fileID: 7364058690186325030, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037851553793497553, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 2.32026
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037851553793497553, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 9.55991
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037851553793497553, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 5.40346
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037851553793497553, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 78
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037851553793497553, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 28
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037851553793497553, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037851553793497553, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037851553793497553, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037851553793497553, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037851553793497553, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037851553793497553, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037851553793497553, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9037851553793497553, guid: effb28081a7e1a5479923045034a3161, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: effb28081a7e1a5479923045034a3161, type: 3}
 --- !u!1001 &978811685
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -44287,7 +44178,7 @@ Transform:
   m_GameObject: {fileID: 1099452463}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: -1}
-  m_LocalPosition: {x: -248.59, y: 40.71, z: -10}
+  m_LocalPosition: {x: -234.76, y: 43.75, z: -10}
   m_LocalScale: {x: 0.8064463, y: 0.8064463, z: 0.8064463}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -44851,7 +44742,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 43b116b25d39bd04c969217527fcbb25, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  weight: 2.5
+  baseWeight: 10
+  autoCalculateWeight: 1
 --- !u!50 &1371100188
 Rigidbody2D:
   serializedVersion: 4
@@ -45003,8 +44895,8 @@ Transform:
   m_GameObject: {fileID: 1371100186}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 83.389, y: 33.39, z: 0.000000059604645}
-  m_LocalScale: {x: 0.63761, y: 0.63761, z: 0.63761}
+  m_LocalPosition: {x: 80.71, y: 34.11, z: 0.000000059604645}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
@@ -46596,8 +46488,8 @@ Transform:
   m_GameObject: {fileID: 4526406250561270682}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 76.35, y: 33.34, z: 0.000000059604645}
-  m_LocalScale: {x: 0.63761, y: 0.63761, z: 0.63761}
+  m_LocalPosition: {x: 78.62, y: 34.420002, z: 0.000000059604645}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 0}
@@ -46860,7 +46752,7 @@ Transform:
   m_GameObject: {fileID: 4025159524309635655}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 79.98, y: 33.5, z: 0}
+  m_LocalPosition: {x: 79.98, y: 30.970001, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
@@ -46991,7 +46883,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 43b116b25d39bd04c969217527fcbb25, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  weight: 2.5
+  baseWeight: 10
+  autoCalculateWeight: 1
 --- !u!61 &8897391461635484240
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -47048,7 +46941,6 @@ SceneRoots:
   - {fileID: 132527962}
   - {fileID: 499660063}
   - {fileID: 1353071419}
-  - {fileID: 974910000}
   - {fileID: 886478172}
   - {fileID: 387913841}
   - {fileID: 7421176532690455592}

--- a/Assets/Scripts/Interactables/MovableObject.cs
+++ b/Assets/Scripts/Interactables/MovableObject.cs
@@ -22,73 +22,55 @@ public class MovableObject : MonoBehaviour, IMovable
 
     private bool _canMove = true;
     private bool _isStopping = false;
+
+    private WeightedObject weighted;
+    
     private void Start()
     {
         this._collider2D = GetComponent<BoxCollider2D>();
-
-        
+        weighted = GetComponent<WeightedObject>();
     }
+
     public void MoveTo(Vector2 position) // parameter comes from ArmBullet
     {
         if (_canMove)
         {
-            _targetPosition = position;
+            if (weighted)
+            {
+                float pushFactor = 1f / (1f + weighted.GetWeight() * 0.1f);
+                _targetPosition = Vector2.Lerp(transform.position, position, pushFactor);
+            }
+            else
+                _targetPosition = position;
+            _canMove = false;
             _isBeingMoved = true;
             SFXManager.Instance.PlaySFX(_moovingSFX);
         }
     }
 
-
     void Update()
     {
-        //revisar y ajustar
-        if (!_isBeingMoved) return;
-
-        _currentPosition = transform.position;
-        Vector2 direction = _targetPosition - _currentPosition;
-        float distance = direction.magnitude;
-
-        if (!_isStopping) //solo check de colision si no esta frenada la caja
+        if (_isBeingMoved)
         {
-            RaycastHit2D hit = Physics2D.BoxCast(_currentPosition, _collider2D.bounds.size, 0, direction.normalized, distance, _obstacleMask);
+            Vector2 direction = _targetPosition - _currentPosition;
+            float distance = direction.magnitude;
 
+            _currentPosition = transform.position;
 
-            if (hit.collider != null)
+            //Suavizado del desplazamiento normal de la caja
+            Vector2 smoothPosition = Vector2.SmoothDamp(_currentPosition, _targetPosition, ref _velocity, _moveSmoothTime);
+
+            if (Vector2.Distance(smoothPosition, _targetPosition) < _stopThreshold)
             {
-                float moveDistance = hit.distance - 0.05f; //para que no se pegue a la colision 
-                if (moveDistance < 0) moveDistance = 0f;
-                Vector2 collisionPoint = _currentPosition + direction.normalized * moveDistance;
-                _targetPosition = collisionPoint;
-            }
-        }
-
-        //Suavizado del desplazamiento normal de la caja
-
-        Vector2 smoothPosition = Vector2.SmoothDamp(_currentPosition, _targetPosition, ref _velocity, _moveSmoothTime);
-        transform.position = smoothPosition;
-
-        if (Vector2.Distance(smoothPosition, _targetPosition) < _stopThreshold) //el threshold editable desde inspector para ajustar a gusto
-        {
-            if (_isStopping)
-            {
-                // Solo se detienne completamente si es frenada suave 
-                _isBeingMoved = false;
                 _velocity = Vector2.zero;
-                _canMove = false;
-                _isStopping = false;
+                _canMove = true;
+                _isBeingMoved = false;
+
+                smoothPosition = Vector2.SmoothDamp(_currentPosition, _targetPosition, ref _velocity, _moveSmoothTime);
             }
+
+            transform.position = smoothPosition;
         }
-    }
-    public void StopMove (Vector2 target) //parametro viene del transform position de la placa de presion o quien frene el mov
-   
-    {
-        _targetPosition = target;
-        _isBeingMoved = true; // Habilita el suavizado
-
-
-        //si quisiera detenner la caja en la placa de presion descomentar esto.
-        //_canMove = false; 
-        //_isStopping = true;
-
+        
     }
 }

--- a/Assets/Scripts/Interactables/Statics/PressurePlate.cs
+++ b/Assets/Scripts/Interactables/Statics/PressurePlate.cs
@@ -32,7 +32,7 @@ public class PressurePlate : MonoBehaviour
         WeightedObject weighted = other.GetComponent<WeightedObject>();
         if (weighted)
         {
-            totalWeight += weighted.weight;
+            totalWeight += weighted.GetWeight();
 
             if (totalWeight >= triggerWeight)
                 ActivatePlate();
@@ -44,7 +44,7 @@ public class PressurePlate : MonoBehaviour
         WeightedObject weighted = other.GetComponent<WeightedObject>();
         if (weighted)
         {
-            totalWeight -= weighted.weight;
+            totalWeight -= weighted.GetWeight();
             if (totalWeight < 0f) totalWeight = 0f;
 
             if (totalWeight < triggerWeight)

--- a/Assets/Scripts/Interactables/Statics/PressurePlate.cs
+++ b/Assets/Scripts/Interactables/Statics/PressurePlate.cs
@@ -4,15 +4,22 @@ using UnityEngine;
 
 public class PressurePlate : MonoBehaviour
 {
-    [SerializeField] private LayerMask _objectLayer; //defino la layer del objeto que me interesa para detectar el trigger (OnPositionObject)
-    [SerializeField] private PuzzleManager _puzzleManager; //Instancia del Manager asociada a un GameObject. El objeto del puzzle con el que interactue, debe tener la misma referencia a esta misma instancia para funcionar (agrupar)
-    [SerializeField] private AudioClip _audioClip;
-    [SerializeField] private bool _needHold;
+    [Header("Weight Settings")]
+    [SerializeField] private float triggerWeight = 0f;
+    [SerializeField] private float totalWeight = 0f;
+    [SerializeField] private bool _needHold = false;
 
+    [SerializeField] private AudioClip _audioClip;
     private Collider2D _collider2D;
     private Animator _animator;
+
     public bool NeedHold { get { return _needHold; } } //prop solo lectura, la uso para detectar en el puzzle que use placa de presion en conjunto.
                                                        //Cuando se resuelve el puzzle, las apaga a todas las relacionadas llamando al metodo publico
+
+    public event System.Action OnPadPressed;
+    public event System.Action OnPadReleased;
+
+    private bool isPressed = false;
 
     private void Start()
     {
@@ -22,52 +29,55 @@ public class PressurePlate : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D other)
     {
-        if (((1 << other.gameObject.layer) & _objectLayer) != 0 )
+        WeightedObject weighted = other.GetComponent<WeightedObject>();
+        if (weighted)
         {
-            Debug.Log("Placa de presion activada");
+            totalWeight += weighted.weight;
 
-            SFXManager.Instance.PlaySFX(_audioClip);
-            _animator.SetBool("IsPressed", true);
-            
-            if(_puzzleManager)
-                _puzzleManager.PuzzleCount(-1); //resto uno al contador si se presiona
-
-            // detect box &stop it / activate lever
-            MovableObject movable = other.GetComponent<MovableObject>();
-
-            if (movable != null)
-            {
-                movable.StopMove(transform.position);
-            }
-            if (!_needHold)
-            {
-
-              _collider2D.enabled = false;
-                //como una no necesita ser mantenida, la "apago" por mas que ya no tenga un objeto encima.
-            }
-          
-            //aca agregaria anims o cambios de sprite, si tan solo los tuviera ;c
+            if (totalWeight >= triggerWeight)
+                ActivatePlate();
         }
+        
     }
     private void OnTriggerExit2D(Collider2D other)
     {
-       // if (!_needHold) return; // si no necesita mantenerse, ignoro el exit para que no me rompa la animacion
-        if (((1 << other.gameObject.layer) & _objectLayer) != 0 && _needHold)
+        WeightedObject weighted = other.GetComponent<WeightedObject>();
+        if (weighted)
         {
-            Debug.Log("Placa de presion desactivada");
+            totalWeight -= weighted.weight;
+            if (totalWeight < 0f) totalWeight = 0f;
 
-            _animator.SetBool("IsPressed", false);
-          //  _collider2D.enabled = true;
-            _puzzleManager.PuzzleCount(+1); // De ser de las placas de presion que requieren estar apretadas en simultaneo,
-                                           // SUMO uno al count si se sale de la placa, para obligar al jugador a pulsarla en simultaneo con otra para alcanzar la cuenta requerida dle puzzle.
+            if (totalWeight < triggerWeight)
+            {
+                if (_needHold)
+                    DeactivatePlate();
+            }
             
-            //aca agregaria anims o cambios de sprite, si tan solo los tuviera ;c
         }
+            
     }
+
+    private void ActivatePlate()
+    {
+        isPressed = true;
+
+        Debug.Log("Placa de presion activada");
+        _animator.SetBool("IsPressed", true);
+        SFXManager.Instance.PlaySFX(_audioClip);
+
+        OnPadPressed?.Invoke();
+    }
+
     public void DeactivatePlate()
     {
+        isPressed = false;
+
         //Metodo publico para que el puzzle pueda apagar la placa de presion, por ejemplo si se resuelve el puzzle y se quiere apagar todas las placas de presion
-        _needHold = false; //desactivo la necesidad de mantener presionada la placa
+        Debug.Log("Placa de presion desactivada");
+        _animator.SetBool("IsPressed", false);
+        SFXManager.Instance.PlaySFX(_audioClip);
+
+        OnPadReleased?.Invoke();
     }
 
 

--- a/Assets/Scripts/Interactables/Statics/WeightedObject.cs
+++ b/Assets/Scripts/Interactables/Statics/WeightedObject.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class WeightedObject : MonoBehaviour
+{
+    public float weight = 5f;
+}

--- a/Assets/Scripts/Interactables/Statics/WeightedObject.cs
+++ b/Assets/Scripts/Interactables/Statics/WeightedObject.cs
@@ -4,5 +4,14 @@ using UnityEngine;
 
 public class WeightedObject : MonoBehaviour
 {
-    public float weight = 5f;
+    [SerializeField] private float baseWeight = 5f;
+    public bool autoCalculateWeight = false;
+
+    public float GetWeight()
+    {
+        if (autoCalculateWeight)
+            return baseWeight * transform.localScale.x * transform.localScale.y * transform.localScale.z;
+        else
+            return baseWeight;
+    }
 }

--- a/Assets/Scripts/Interactables/Statics/WeightedObject.cs.meta
+++ b/Assets/Scripts/Interactables/Statics/WeightedObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43b116b25d39bd04c969217527fcbb25
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Pressure pads use weight instead of layers
-Allows for puzzles requiring stacking multiple objects on plate to work
-Any object can be turned into weighted object (add "weighted" script to it, requires 2D collider)
-Puzzle logic removed from object
-Removed "Stop Movable object movement" logic from object, should be handled elsewhere